### PR TITLE
fix: cronjob

### DIFF
--- a/.kube-workflow/common/templates/cronjob.yaml
+++ b/.kube-workflow/common/templates/cronjob.yaml
@@ -2,9 +2,9 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   labels:
-    component: pe-cronjob
+    component: ds-cronjob
     application: enfants-du-spectacle
-  name: pe-cronjob
+  name: ds-cronjob
 spec:
   schedule: 10 * * * *
   concurrencyPolicy: Forbid
@@ -13,14 +13,14 @@ spec:
       template:
         metadata:
           labels:
-            component: pe-cronjob
+            component: ds-cronjob
             application: enfants-du-spectacle
-          name: pe-cronjob
+          name: ds-cronjob
         spec:
           restartPolicy: OnFailure
           containers:
             - name: cronjob-container
-              image: registry.hub.docker.com/library/curlimages/curl
+              image: curlimages/curl:7.84.0
               command:
                 - /bin/sh
                 - -c
@@ -33,6 +33,3 @@ spec:
                     name: backend-sealed-secret
                 - configMapRef:
                     name: backend-configmap
-              env:
-                - name: hello
-                  value: world


### PR DESCRIPTION
Il y a apparemment un souci avec ce cronjob : `  Failed to pull image "registry.hub.docker.com/library/curlimages/curl": rpc error: code = NotFound desc = failed to pull and unpack image "registry.hub.docker.com/library/curlimages/curl:latest": failed to resolve reference "registry.hub.docker.com/library/curlimages/curl:latest": registry.hub.docker.com/library/curlimages/curl:latest: not found`