### PR TITLE
chore: remove stdout logs

### DIFF
--- a/formulaire/pages/api/comments/index.tsx
+++ b/formulaire/pages/api/comments/index.tsx
@@ -75,7 +75,7 @@ const post: NextApiHandler = async (req, res) => {
   let data = JSON.parse(req.body) as Comments;
   //@ts-ignore
   data.userId = session?.dbUser.id;
-  console.log("comment to create : ", data);
+  // console.log("comment to create : ", data);
   try {
     const comment = await prisma.comments.create({ data });
     res.status(200).json(comment);

--- a/formulaire/pages/api/docs/[id].tsx
+++ b/formulaire/pages/api/docs/[id].tsx
@@ -75,7 +75,7 @@ export const uploadFile = (
   return new Promise((resolve, reject) => {
     form.parse(req, (err, fields, files) => {
       if (err) reject(err);
-      console.log("files : ", files);
+      // console.log("files : ", files);
       try {
         const key = process.env.CIPHER_KEY as string;
         const iv = process.env.CIPHER_IV as string;

--- a/formulaire/pages/api/dossier/[id].tsx
+++ b/formulaire/pages/api/dossier/[id].tsx
@@ -6,7 +6,7 @@ import client from "src/lib/prismaClient";
 
 const handler: NextApiHandler = async (req, res) => {
   const session = await getServerSession(req, res, authOptions);
-  console.log("session id", session);
+  // console.log("session id", session);
   if (!session) {
     res.status(401).end();
     return;

--- a/formulaire/pages/api/enfants/dossier/[id].tsx
+++ b/formulaire/pages/api/enfants/dossier/[id].tsx
@@ -24,7 +24,7 @@ function getId(req: NextApiRequest): number {
 
 const get: NextApiHandler = async (req, res) => {
   const session = await getServerSession(req, res, authOptions);
-  console.log("order : ", req.query.order);
+  // console.log("order : ", req.query.order);
   try {
     const dossierId = getId(req);
     const dossierConcerned = await client.dossier.findUnique({

--- a/formulaire/pages/api/remunerations/[id].tsx
+++ b/formulaire/pages/api/remunerations/[id].tsx
@@ -21,7 +21,7 @@ const handler: NextApiHandler = async (req, res) => {
 const remove: NextApiHandler = async (req, res) => {
   const remunerationId = Number(req.body as string);
   try {
-    console.log("remunerationId: ", remunerationId);
+    // console.log("remunerationId: ", remunerationId);
     await client.remuneration.delete({
       where: { id: remunerationId },
     });

--- a/formulaire/pages/api/remunerations/index.tsx
+++ b/formulaire/pages/api/remunerations/index.tsx
@@ -37,7 +37,7 @@ const post: NextApiHandler = async (req, res) => {
 const remove: NextApiHandler = async (req, res) => {
   const enfantId = Number(req.body as string);
   try {
-    console.log("ENFANT ID: ", enfantId);
+    // console.log("ENFANT ID: ", enfantId);
     await prisma.remuneration.deleteMany({
       where: { enfantId: enfantId },
     });

--- a/formulaire/pages/api/sirene/index.tsx
+++ b/formulaire/pages/api/sirene/index.tsx
@@ -20,7 +20,7 @@ const handler: NextApiHandler = async (req, res) => {
 const get: NextApiHandler = async (req, res) => {
 
     const siret = req.query.siret || ''
-    console.log('token : ', process.env.TOKEN_SIRENE)
+    // console.log('token : ', process.env.TOKEN_SIRENE)
 
     let fetching = await fetch(`https://api.insee.fr/entreprises/sirene/V3.11/siret/${siret}`,{
         method: 'GET',

--- a/formulaire/pages/api/societe/index.tsx
+++ b/formulaire/pages/api/societe/index.tsx
@@ -62,7 +62,7 @@ const post: NextApiHandler = async (req, res) => {
     const societe = await prisma.societeProduction.create({
       data: { ...societeData.parse(data) },
     });
-    console.log("societe created : ", societe);
+    // console.log("societe created : ", societe);
     res.status(200).json(societe);
   } catch (e: unknown) {
     console.log(e);

--- a/formulaire/pages/api/sync/inc/remunerations/index.tsx
+++ b/formulaire/pages/api/sync/inc/remunerations/index.tsx
@@ -21,7 +21,7 @@ const get: NextApiHandler = async (req, res) => {
     }
   }
   const externalIds = ids.map((id: string) => parseInt(id)) as number[];
-  console.log("data externalIds received : ", data);
+  // console.log("data externalIds received : ", data);
 
   if (data.token !== process.env.API_KEY_SDP) {
     res.status(401).json({ error: `Unauthorized` });
@@ -33,7 +33,7 @@ const get: NextApiHandler = async (req, res) => {
         },
       },
     });
-    console.log("REMUNERATIONS: ", remunerations);
+    // console.log("REMUNERATIONS: ", remunerations);
     res.status(200).json(remunerations);
   }
 };

--- a/formulaire/pages/api/sync/out/dossiers/[id].tsx
+++ b/formulaire/pages/api/sync/out/dossiers/[id].tsx
@@ -31,7 +31,7 @@ const get: NextApiHandler = async (req, res) => {
       method: "GET",
     }).then(async (r) => {
       if (!r.ok) {
-        console.log("r : ", r.status);
+        console.log("r : ", r.status); // TODO: to be replaced by an error ?
       }
       return r.json();
     });

--- a/formulaire/pages/api/sync/out/dossiers/index.tsx
+++ b/formulaire/pages/api/sync/out/dossiers/index.tsx
@@ -35,7 +35,7 @@ const post: NextApiHandler = async (req, res) => {
     societeProduction: SocieteProduction;
     enfants: EnfantData[];
   };
-  console.log("dossier to send : ", data);
+  // console.log("dossier to send : ", data);
 
   if (
     data.dossier.statut === "BROUILLON" ||
@@ -47,7 +47,7 @@ const post: NextApiHandler = async (req, res) => {
       method: data.dossier.statut === "BROUILLON" ? "POST" : "PUT",
     }).then(async (r) => {
       if (!r.ok) {
-        console.log("r : ", r.status);
+        console.log("r : ", r.status); // TODO: to be replaced by an error ?
         res.status(500).json({ error: `Something went wrong : ${r.status}` });
       }
       return r.json();


### PR DESCRIPTION
Il y a beaucoup de `console.log`, principalement coté backend.
Il serait préférable de limiter au maximum les données qui sont output par l'application sur stdout.
Cette PR traite exclusivement les logs de l'API. Il y a probablement un peu de nettoyage à faire aussi coté front-end.